### PR TITLE
Fix 429 errors by implementing exponential backoff

### DIFF
--- a/src/gmail/index.js
+++ b/src/gmail/index.js
@@ -28,7 +28,7 @@ export async function handleLogin() {
  * Print all messages in the authorized user's inbox. If no messages
  * are found an appropriate message is printed.
  */
-export async function loadMessagesToDb(nextPageToken) {
+export async function loadMessagesToDb(nextPageToken, retryCount = 0) {
     let response;
     try {
         response = await gapi.client.gmail.users.messages.list({
@@ -38,7 +38,13 @@ export async function loadMessagesToDb(nextPageToken) {
             pageToken: nextPageToken,
         });
     } catch (err) {
-        document.getElementById('content').innerText = err.message;
+        if (err.status === 429) {
+            const backoffTime = Math.pow(2, retryCount) * 1000;
+            console.log(`Received 429 error. Retrying in ${backoffTime / 1000} seconds...`);
+            setTimeout(() => loadMessagesToDb(nextPageToken, retryCount + 1), backoffTime);
+        } else {
+            document.getElementById('content').innerText = err.message;
+        }
         return;
     }
     let messages = response.result.messages;
@@ -68,5 +74,5 @@ export async function loadMessagesToDb(nextPageToken) {
 
     console.log(response.result.nextPageToken, response.result);
 
-    setTimeout(() => loadMessagesToDb(response.result.nextPageToken), 15000);
+    setTimeout(() => loadMessagesToDb(response.result.nextPageToken), 30000);
 }


### PR DESCRIPTION
Implement exponential backoff to handle 429 errors and adjust timeout duration between API requests in `loadMessagesToDb` function.

* **src/gmail/index.js**
  - Add `retryCount` parameter to `loadMessagesToDb` function.
  - Implement exponential backoff mechanism for handling 429 errors.
  - Adjust timeout duration between API requests from 15 seconds to 30 seconds.

* **src/poc/gmail.js**
  - Add `retryCount` parameter to `loadMessagesToDb` function.
  - Implement exponential backoff mechanism for handling 429 errors.
  - Adjust timeout duration between API requests from 15 seconds to 30 seconds.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sparksis/email-analyzer/pull/13?shareId=a2b70da0-ec91-48e9-8851-486ba96938d1).