### PR TITLE
Add EmailMasonryView component with email tiles

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+  "tasks": {
+    "test": "npm install && npm test",
+    "build": "npm install && npm run build",
+    "launch": "npm install && npm start"
+  }
+}

--- a/src/components/DetailView/index.js
+++ b/src/components/DetailView/index.js
@@ -2,25 +2,41 @@ import React from "react";
 import messages from "../../poc/messages";
 import SummaryTree from "../SummaryTree";
 import ToContainer from "./ToAddress";
+import MasonryView from "../MasonryView";
 import './DetailView.scss'
 
 export class DetailView extends React.Component {
 
     constructor(props) {
         super(props);
-        this.state = { toAddresses: null, filter: null }
+        this.state = { toAddresses: null, filter: null, emailData: [] }
     }
 
     async componentDidMount() {
         this.setState({
             toAddresses: await messages.orderBy('to').uniqueKeys(),
         });
+        this.loadEmailData();
+    }
+
+    async loadEmailData() {
+        const emailData = await messages.toArray();
+        const emailCountBySender = emailData.reduce((acc, email) => {
+            acc[email.from] = (acc[email.from] || 0) + 1;
+            return acc;
+        }, {});
+        const formattedEmailData = Object.keys(emailCountBySender).map(sender => ({
+            sender,
+            emailCount: emailCountBySender[sender]
+        }));
+        this.setState({ emailData: formattedEmailData });
     }
 
     render() {
         return <div className="DetailView">
             <ToContainer addresses={this.state.toAddresses} onChange={(address) => this.setState({ filter: address })} />
             <SummaryTree filter={this.state.filter} />
+            <MasonryView emailData={this.state.emailData} />
         </div>;
     }
 }

--- a/src/components/EmailMasonryView/EmailMasonryView.js
+++ b/src/components/EmailMasonryView/EmailMasonryView.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Box } from '@mui/material';
+import { EmailTile } from './EmailTile';
+
+const MasonryContainer = styled(Box)`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+`;
+
+const EmailMasonryView = ({ emailData }) => {
+  return (
+    <MasonryContainer>
+      {emailData.map(({ sender, emailCount }) => (
+        <EmailTile key={sender} sender={sender} emailCount={emailCount} />
+      ))}
+    </MasonryContainer>
+  );
+};
+
+export default EmailMasonryView;

--- a/src/components/EmailMasonryView/EmailMasonryView.stories.js
+++ b/src/components/EmailMasonryView/EmailMasonryView.stories.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import EmailMasonryView from './EmailMasonryView';
+
+export default {
+  title: 'Components/EmailMasonryView',
+  component: EmailMasonryView,
+};
+
+const Template = (args) => <EmailMasonryView {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  emailData: [
+    { sender: 'example1@example.com', emailCount: 1 },
+    { sender: 'example2@example.com', emailCount: 3 },
+    { sender: 'example3@example.com', emailCount: 7 },
+    { sender: 'example4@example.com', emailCount: 16 },
+    { sender: 'example5@example.com', emailCount: 20 },
+  ],
+};

--- a/src/components/EmailMasonryView/EmailTile.js
+++ b/src/components/EmailMasonryView/EmailTile.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Tile = styled.div`
+  border: 1px solid #ccc;
+  margin: 10px;
+  padding: 10px;
+  border-radius: 5px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+`;
+
+const TinyTile = styled(Tile)`
+  height: 20px;
+`;
+
+const SmallTile = styled(Tile)`
+  height: 40px;
+`;
+
+const MediumTile = styled(Tile)`
+  height: 60px;
+  display: flex;
+  align-items: center;
+`;
+
+const LargeTile = styled(Tile)`
+  height: 160px;
+`;
+
+const ExtraLargeTile = styled(Tile)`
+  height: 240px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const ProfilePhoto = styled.div`
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background-color: #ccc;
+  margin-right: 10px;
+`;
+
+const SubjectPreview = styled.div`
+  flex: 1;
+  background-color: #f0f0f0;
+  height: 100px;
+  margin-top: 10px;
+`;
+
+const EmailTile = ({ sender, emailCount }) => {
+  if (emailCount === 1) {
+    return <TinyTile>{sender}</TinyTile>;
+  } else if (emailCount < 5) {
+    return <SmallTile>{sender}</SmallTile>;
+  } else if (emailCount < 15) {
+    return (
+      <MediumTile>
+        <ProfilePhoto />
+        <div>{sender}</div>
+      </MediumTile>
+    );
+  } else if (emailCount < 16) {
+    return (
+      <LargeTile>
+        <div>{sender}</div>
+        <SubjectPreview />
+      </LargeTile>
+    );
+  } else {
+    return <ExtraLargeTile>Placeholder</ExtraLargeTile>;
+  }
+};
+
+export default EmailTile;

--- a/src/components/EmailMasonryView/EmailTile.stories.js
+++ b/src/components/EmailMasonryView/EmailTile.stories.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import EmailTile from './EmailTile';
+
+export default {
+  title: 'Components/EmailTile',
+  component: EmailTile,
+};
+
+const Template = (args) => <EmailTile {...args} />;
+
+export const Tiny = Template.bind({});
+Tiny.args = {
+  sender: 'example1@example.com',
+  emailCount: 1,
+};
+
+export const Small = Template.bind({});
+Small.args = {
+  sender: 'example2@example.com',
+  emailCount: 3,
+};
+
+export const Medium = Template.bind({});
+Medium.args = {
+  sender: 'example3@example.com',
+  emailCount: 7,
+};
+
+export const Large = Template.bind({});
+Large.args = {
+  sender: 'example4@example.com',
+  emailCount: 16,
+};
+
+export const ExtraLarge = Template.bind({});
+ExtraLarge.args = {
+  sender: 'example5@example.com',
+  emailCount: 20,
+};

--- a/src/components/EmailMasonryView/index.js
+++ b/src/components/EmailMasonryView/index.js
@@ -1,0 +1,2 @@
+export { default as EmailMasonryView } from './EmailMasonryView';
+export { default as EmailTile } from './EmailTile';

--- a/src/components/EmailTile/EmailTile.scss
+++ b/src/components/EmailTile/EmailTile.scss
@@ -1,31 +1,3 @@
-.DetailView {
-  padding: 1em;
-}
-
-body.light-theme .DetailView {
-  background-color: #ffffff;
-  color: #333333;
-}
-
-body.dark-theme .DetailView {
-  background-color: #252725;
-  color: #ffffff;
-}
-
-.masonry-container {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-
-.masonry-item {
-  margin: 10px;
-  padding: 10px;
-  border: 1px solid #ccc;
-  border-radius: 5px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-}
-
 .tiny-tile {
   height: 20px;
 }

--- a/src/components/EmailTile/index.js
+++ b/src/components/EmailTile/index.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import styled from 'styled-components';
+import './EmailTile.scss';
+
+const Tile = styled.div`
+  border: 1px solid #ccc;
+  margin: 10px;
+  padding: 10px;
+  border-radius: 5px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+`;
+
+const TinyTile = styled(Tile)`
+  height: 20px;
+`;
+
+const SmallTile = styled(Tile)`
+  height: 40px;
+`;
+
+const MediumTile = styled(Tile)`
+  height: 60px;
+  display: flex;
+  align-items: center;
+`;
+
+const LargeTile = styled(Tile)`
+  height: 160px;
+`;
+
+const ExtraLargeTile = styled(Tile)`
+  height: 240px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const ProfilePhoto = styled.div`
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background-color: #ccc;
+  margin-right: 10px;
+`;
+
+const SubjectPreview = styled.div`
+  flex: 1;
+  background-color: #f0f0f0;
+  height: 100px;
+  margin-top: 10px;
+`;
+
+export const EmailTile = ({ sender, emailCount }) => {
+  if (emailCount === 1) {
+    return <TinyTile>{sender}</TinyTile>;
+  } else if (emailCount < 5) {
+    return <SmallTile>{sender}</SmallTile>;
+  } else if (emailCount < 15) {
+    return (
+      <MediumTile>
+        <ProfilePhoto />
+        <div>{sender}</div>
+      </MediumTile>
+    );
+  } else if (emailCount < 16) {
+    return (
+      <LargeTile>
+        <div>{sender}</div>
+        <SubjectPreview />
+      </LargeTile>
+    );
+  } else {
+    return <ExtraLargeTile>Placeholder</ExtraLargeTile>;
+  }
+};

--- a/src/components/MasonryView/MasonryView.scss
+++ b/src/components/MasonryView/MasonryView.scss
@@ -1,0 +1,13 @@
+.masonry-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.masonry-item {
+  margin: 10px;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}

--- a/src/components/MasonryView/index.js
+++ b/src/components/MasonryView/index.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import styled from 'styled-components';
+import { EmailTile } from '../EmailTile';
+import './MasonryView.scss';
+
+const MasonryContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+`;
+
+export const MasonryView = ({ emailData }) => {
+  return (
+    <MasonryContainer>
+      {emailData.map(({ sender, emailCount }) => (
+        <EmailTile key={sender} sender={sender} emailCount={emailCount} />
+      ))}
+    </MasonryContainer>
+  );
+};


### PR DESCRIPTION
Add EmailMasonryView component to render a masonry view of email tiles based on the number of emails from a sender.

* **DetailView Component**
  - Import MasonryView component.
  - Add emailData state and loadEmailData method to fetch and format email data.
  - Render MasonryView component with emailData.

* **EmailTile Component**
  - Create EmailTile component to render individual email tiles with different sizes.
  - Implement logic to render tile content based on the tile size.

* **MasonryView Component**
  - Create MasonryView component to render a masonry view of email tiles.
  - Use styled-components for styling.

* **Storybook Stories**
  - Add stories for EmailMasonryView and EmailTile components to showcase different tile sizes and email data.

* **Styling**
  - Add CSS styles for different tile sizes and masonry container.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sparksis/email-analyzer/pull/26?shareId=6d9e951b-9330-45ce-8170-c22647f90cc5).